### PR TITLE
Bump weight to 8 for post-2021 event slides

### DIFF
--- a/json/slides.json
+++ b/json/slides.json
@@ -560,7 +560,7 @@
 		"caption": "On October 3, 2023, Rep. Matt Gaetz's motion to vacate the chair succeeded 216-210, making Kevin McCarthy the first Speaker in U.S. history to be removed by a House vote.",
 		"link": "/rollcall/RH1180518",
 		"mask": "medium",
-		"weight": 4
+		"weight": 8
 	},
 	{
 		"image": "mike_johnson_speaker.png",
@@ -568,7 +568,7 @@
 		"caption": "After three weeks without a Speaker and multiple failed bids, Rep. Mike Johnson of Louisiana was elected Speaker of the House on October 25, 2023.",
 		"link": "/rollcall/RH1180522",
 		"mask": "medium",
-		"weight": 4
+		"weight": 8
 	},
 	{
 		"image": "george_santos.png",
@@ -576,7 +576,7 @@
 		"caption": "Rep. George Santos (R-NY) was expelled from the House 311-114 on December 1, 2023 — only the third expulsion in House history — after being indicted on 23 federal counts.",
 		"link": "/rollcall/RH1180686",
 		"mask": "light",
-		"weight": 4
+		"weight": 8
 	},
 	{
 		"image": "tiktok.png",
@@ -584,7 +584,7 @@
 		"caption": "In 2024, Congress voted to force ByteDance to sell TikTok or face a ban, citing national security concerns about Chinese ownership of an app used by 170 million Americans.",
 		"link": "/rollcall/RH1180804",
 		"mask": "light",
-		"weight": 2
+		"weight": 8
 	},
 	{
 		"image": "zelensky_congress.png",
@@ -592,7 +592,7 @@
 		"caption": "After months of deadlock, the House passed a $95 billion foreign aid package for Ukraine, Israel, and Taiwan in April 2024, with Speaker Johnson defying his own right flank to bring it to the floor.",
 		"link": "/rollcall/RH1180869",
 		"mask": "light",
-		"weight": 2
+		"weight": 8
 	},
 	{
 		"image": "biden_social_security.png",
@@ -600,7 +600,7 @@
 		"caption": "In November 2024, the House passed the Social Security Fairness Act 327-75, eliminating provisions that had reduced benefits for roughly 3 million teachers, firefighters, and police officers.",
 		"link": "/rollcall/RH1181174",
 		"mask": "medium",
-		"weight": 2
+		"weight": 8
 	},
 	{
 		"image": "mike_johnson_speaker.png",
@@ -608,7 +608,7 @@
 		"caption": "Mike Johnson was re-elected Speaker on January 3, 2025, by a narrow 218-215 margin, kicking off the 119th Congress with Republicans holding the slimmest of majorities.",
 		"link": "/rollcall/RH1190001",
 		"mask": "medium",
-		"weight": 4
+		"weight": 8
 	},
 	{
 		"image": "pete_hegseth.png",
@@ -616,7 +616,7 @@
 		"caption": "Pete Hegseth was confirmed as Secretary of Defense on January 24, 2025, on a 50-50 tie with Vice President JD Vance casting the tie-breaking vote — the first such tie-break for a cabinet confirmation since Betsy DeVos in 2017.",
 		"link": "/rollcall/RS1190015",
 		"mask": "medium",
-		"weight": 2
+		"weight": 8
 	},
 	{
 		"image": "debt.png",
@@ -624,7 +624,7 @@
 		"caption": "President Joe Biden and House Speaker Kevin McCarthy make a historic compromise to prevent a default on the national debt. ",
 		"link": "/rollcall/RH1180242",
 		"mask": "medium",
-		"weight": 2
+		"weight": 8
 	},
 	{
 		"image": "native-americans.png",
@@ -1047,7 +1047,7 @@
 		"caption": "With powerful opiate fentanyl killing many Americans, Congress gave law enforcement the proper tools to fight the epicdemic.",
 		"link": "/rollcall/RH1180236",
 		"mask": "light",
-		"weight": 2
+		"weight": 8
 	},
         {
 		"image": "placenta.png",
@@ -1287,7 +1287,7 @@
 		"caption": "After being exposed for lying about various subjects, George Santos was put up to a vote for punishment by the chamber.",
 		"link": "/rollcall/RH1180216",
 		"mask": "none",
-		"weight": 2
+		"weight": 8
 	},
         {
 		"image": "hamilton.png",


### PR DESCRIPTION
Increases the carousel rotation weight to 8 for the eleven Key Votes / In The News slides covering 118th- and 119th-Congress events (2023 and later) so recent events surface more prominently. Navigation slides and the McCarthy speakership slide (already w=10) are left as-is.